### PR TITLE
treewide: add descriptions to various module options

### DIFF
--- a/micros/modules/config/users.nix
+++ b/micros/modules/config/users.nix
@@ -13,30 +13,43 @@
     options = {
       name = mkOption {
         type = types.str;
+        default = "";
+        description = "Account Username";
       };
 
       uid = mkOption {
         type = with types; nullOr int;
         default = null;
+        description = "Account User ID";
       };
 
+      gid = mkOption {
+        type = with types; nullOr int;
+        default = config.uid;
+        description = "Account group ID";
+      };
       home = mkOption {
         type = types.path;
         default = "/var/empty";
+        description = "Account home directory";
       };
 
       password = mkOption {
         type = types.str;
+        default = "x";
+        description = "Hashed account password";
       };
 
       shell = mkOption {
         type = with types; nullOr (either shellPackage path);
         default = "/run/current-system/sw/bin/bash";
+        description = "Account login shell";
       };
 
       packages = mkOption {
         type = types.listOf types.package;
         default = [];
+        description = "User-wide package list";
       };
     };
 
@@ -56,11 +69,13 @@ in {
       root = {
         uid = 0;
         password = "";
+        home = "/root";
       };
 
       micros = {
         uid = 1000;
         password = "";
+        home = "/home/micros";
       };
     };
 
@@ -70,7 +85,7 @@ in {
           #!${pkgs.runtimeShell}
           # Make home directories
           ${lib.concatLines (builtins.attrValues (builtins.mapAttrs (name: value: "mkdir -p ${value.home}") config.users))}
-          ${lib.concatLines (builtins.attrValues (builtins.mapAttrs (name: value: "chown ${toString value.uid}:${toString value.uid} -f -R ${value.home}") config.users))}
+          ${lib.concatLines (builtins.attrValues (builtins.mapAttrs (name: value: "chown ${toString value.uid}:${toString value.gid} -f -R ${value.home}") config.users))}
           exec ${pkgs.runit}/bin/sv pause /etc/service/user-init
         '';
       };
@@ -78,7 +93,7 @@ in {
 
     environment.etc = mkMerge [
       {
-        passwd.text = lib.concatLines (builtins.attrValues (builtins.mapAttrs (name: value: "${name}:${value.password}:${toString value.uid}:${toString value.uid}::${value.home}:${value.shell}") config.users));
+        passwd.text = lib.concatLines (builtins.attrValues (builtins.mapAttrs (name: value: "${name}:${value.password}:${toString value.uid}:${toString value.gid}::${value.home}:${value.shell}") config.users));
       }
 
       (lib.mapAttrs' (_: {

--- a/micros/modules/config/users.nix
+++ b/micros/modules/config/users.nix
@@ -28,9 +28,10 @@
         default = config.uid;
         description = "Account group ID";
       };
+
       home = mkOption {
         type = types.path;
-        default = "/var/empty";
+        default = "/home/${name}";
         description = "Account home directory";
       };
 
@@ -75,7 +76,6 @@ in {
       micros = {
         uid = 1000;
         password = "";
-        home = "/home/micros";
       };
     };
 

--- a/micros/modules/system/boot/runit/services.nix
+++ b/micros/modules/system/boot/runit/services.nix
@@ -36,27 +36,27 @@
       # if any, and describe the process of execution. For example, can any one of
       # those options be omitted? Should be documented.
       runScript = mkOption {
-        type = types.str;
-        default = "#!${pkgs.runtimeShell}";
+        type = types.nullOr types.str;
+        default = null;
         description = ''
-          Script ran on service startup. Creates the /etc/service/<name>/run file.
+          Script ran on service startup. Creates the {file}`/etc/service/<name>/run` file.
           Services are ran constantly by default. Use `sv pause <name>` in the run
           script to make the script act as a one-shot.
         '';
       };
 
       finishScript = mkOption {
-        type = types.str;
-        default = "#!${pkgs.runtimeShell}";
+        type = types.nullOr types.str;
+        default = null;
         description = ''
-          Script ran on service shutdown. Creates the /etc/service/<name>/finish file.
+          Script ran on service shutdown. Creates the {file}`/etc/service/<name>/finish` file.
           Can be undefined.
         '';
       };
 
       confScript = mkOption {
-        type = types.str;
-        default = "#!${pkgs.runtimeShell}";
+        type = types.nullOr types.str;
+        default = null;
         description = ''
           Script which can be sourced by the run script to define variables.
           Not used by default, and can be undefined.
@@ -81,7 +81,7 @@ in {
       (mapAttrs' (name: value: {
           inherit (value) enable;
           name = "service/${name}/run";
-          value = {
+          value = mkIf (value.runScript != null) {
             text = ''${value.runScript}'';
             mode = "0755";
           };
@@ -92,7 +92,7 @@ in {
           inherit (value) enable;
           name = "service/${name}/finish";
 
-          value = {
+          value = mkIf (value.finishScript != null) {
             text = ''${value.finishScript}'';
             mode = "0755";
           };
@@ -102,7 +102,7 @@ in {
       (mapAttrs' (name: value: {
           inherit (value) enable;
           name = "service/${name}/conf";
-          value = {
+          value = mkIf (value.confScript != null) {
             text = ''${value.confScript}'';
             mode = "0755";
           };

--- a/micros/modules/system/boot/runit/services.nix
+++ b/micros/modules/system/boot/runit/services.nix
@@ -38,16 +38,29 @@
       runScript = mkOption {
         type = types.str;
         default = "#!${pkgs.runtimeShell}";
+        description = ''
+          Script ran on service startup. Creates the /etc/service/<name>/run file.
+          Services are ran constantly by default. Use `sv pause <name>` in the run
+          script to make the script act as a one-shot.
+        '';
       };
 
       finishScript = mkOption {
         type = types.str;
         default = "#!${pkgs.runtimeShell}";
+        description = ''
+          Script ran on service shutdown. Creates the /etc/service/<name>/finish file.
+          Can be undefined.
+        '';
       };
 
       confScript = mkOption {
         type = types.str;
         default = "#!${pkgs.runtimeShell}";
+        description = ''
+          Script which can be sourced by the run script to define variables.
+          Not used by default, and can be undefined.
+        '';
       };
     };
 


### PR DESCRIPTION
Adds documentation for runit.services.<name> modules and users.<name> modules. Also adds separation of UID and GID, and a default password of “x”, denying login.