### PR TITLE
Add basic networking implementation using ifupdown-ng

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -88,6 +88,7 @@
 
     legacyPackages = forSupportedSystems (system: {
       linux-rpi2 = nixpkgs.legacyPackages.${system}.callPackage ./pkgs/linux-rpi.nix {};
+      ifupdown-ng = nixpkgs.legacyPackages.${system}.callPackage ./pkgs/ifupdown-ng.nix {};
     });
 
     # Custom library to provide additional utilities for 3rd party consumption.

--- a/micros/modules/config/system-path.nix
+++ b/micros/modules/config/system-path.nix
@@ -18,6 +18,8 @@ let
     pkgs.iputils
     pkgs.procps
     pkgs.bashInteractive
+    pkgs.dhcpcd
+    (pkgs.callPackage ../../../pkgs/ifupdown-ng.nix {})
   ];
 in {
   options = {

--- a/micros/modules/environment.nix
+++ b/micros/modules/environment.nix
@@ -37,13 +37,6 @@ in {
       bashrc.text = "export PATH=/run/current-system/sw/bin";
       profile.text = "export PATH=/run/current-system/sw/bin:/etc/profiles/per-user/$USER/bin";
 
-      "resolv.conf".text = "nameserver 10.0.2.3";
-
-      "nsswitch.conf".text = ''
-        hosts:     files  dns   myhostname mymachines
-        networks:  files dns
-      '';
-
       "services".source = pkgs.iana-etc + "/etc/services";
 
       group.text = ''

--- a/micros/modules/networking.nix
+++ b/micros/modules/networking.nix
@@ -3,46 +3,74 @@
   lib,
   ...
 }: let
-  inherit (lib) mkIf mkOption mkEnableOption;
+  inherit (lib) mkIf mkOption mkDefault mkMerge;
   inherit (lib) types;
-in {
-  options = {
-    not-os.simpleStaticIp = {
-      # Assign a static IP of 10.0.2.15
-      enable = mkEnableOption ''
-        setting a simple static IP during runit stage-1.
-
-
-        The static IP will be set to the value of {option}`not-os.simpleStaticIp.address`
-        therefore you must configure address, route, gateway and interface accordingly.
-      '';
-
-      address = mkOption {
-        type = types.str;
-        default = "10.0.2.15";
-        description = "The static IP to be assigned to the machine in stage-1";
+  interfaceOpts = types.submodule {
+    options = {
+      enable = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Whether to enable the interface. This determines if the interface will have an entry in the /etc/network/interfaces file.
+        '';
       };
-
-      route = mkOption {
+      name = mkOption {
         type = types.str;
-        default = "10.0.2.0/24";
-        description = "The network route to be used for directing traffic.";
+        description = ''
+          Name of the interface. This is used in the /etc/network/interfaces file and needs to be set to a valid network interface, e.g. eth0, ens1p0, wlp2s0, etc.
+        '';
       };
-
-      interface = mkOption {
-        type = types.str;
-        default = "eth0";
-        example = "ens33";
-        description = "The network interface to be used for the static IP configuration.";
+      dhcp = mkOption {
+        type = types.nullOr types.bool;
+        description = ''
+          Whether to use DHCP for the interface. When null (default), DHCP is used if ipv4 has no manually configured addresses.
+        '';
+        default = null;
       };
-
-      gateway = mkOption {
-        type = types.str;
-        default = "10.0.2.2";
-        description = "The IP address of the default gateway.";
+      slaac = mkOption {
+        type = types.nullOr types.bool;
+        description = ''
+          Whether to use SLAAC for configuring IPV6 on the interface. When null (default), SLAAC is used if ipv6 has no manually configured addresses.
+        '';
+        default = null;
+      };
+      ipv4 = {
+        address = mkOption {
+          type = with types; nullOr (strMatching "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\/(3[0-2]|[1-2]?\d)$");
+          description = ''
+            IPV4 address given to the interface, with the subnet mask. Given as "x.x.x.x/xx".
+          '';
+          default = null;
+        };
+        gateway = mkOption {
+          type = with types; nullOr (strMatching "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\/(3[0-2]|[1-2]?\d)$");
+          description = ''
+            IPV4 address used as the network gateway. Given as "x.x.x.x/xx".
+          '';
+          default = null;
+        };
+      };
+      ipv6 = {
+        address = mkOption {
+          type = with types; nullOr (strMatching "(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))\/([1-9]|[1-9][0-9]|1[01][0-9]|12[0-8])");
+          description = ''
+            IPV6 address given to the interface, with the subnet mask.
+          '';
+          default = null;
+        };
+        gateway = mkOption {
+          type = with types;
+            nullOr (strMatching "(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))");
+          description = ''
+            IPV6 address used as the network gateway.
+          '';
+          default = null;
+        };
       };
     };
-
+  };
+in {
+  options = {
     networking = {
       hostName = mkOption {
         default = "micros"; # this defaults to distroId in nixpkgs, which we do not have.
@@ -72,7 +100,20 @@ in {
           WARNING: Do not use underscores (_) or you may run into unexpected issues.
         '';
       };
-
+      interfaces = mkOption {
+        type = with types; listOf interfaceOpts;
+        description = ''
+          The list of interfaces to configure. By default, all network interfaces detected on startup are brought up with DHCP. Use this to manually configure interfaces and set static IPs.
+        '';
+        default = [];
+      };
+      nameservers = mkOption {
+        type = with types; listOf (strMatching "(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])");
+        description = ''
+          The list of nameservers used. This can be overrided by DHCP. Defaults to cloudflare DNS (1.1.1.1, 1.0.0.1).
+        '';
+        default = ["1.1.1.1" "1.0.0.1"];
+      };
       hostId = mkOption {
         default = null;
         example = "4e98920d";
@@ -94,7 +135,18 @@ in {
         '';
       };
 
-      dhcp.enable = mkEnableOption "dhcp";
+      dhcp = {
+        enable = mkOption {
+          type = types.bool;
+          description = ''Whether to enable DHCP globally. This is overrided by individual interface settings. Defaults to true'';
+          default = true;
+        };
+        overrideNameservers = mkOption {
+          type = types.bool;
+          description = ''Whether to use DHCP nameservers over configured ones. Defaults to false.'';
+          default = false;
+        };
+      };
       timeServers = mkOption {
         type = types.listOf types.str;
         default = [
@@ -111,8 +163,56 @@ in {
   };
 
   config = {
-    environment.etc.hostname = mkIf (config.networking.hostName != "") {
-      text = config.networking.hostName + "\n";
+    environment.etc = {
+      hostname = mkIf (config.networking.hostName != "") {
+        text = config.networking.hostName + "\n";
+      };
+      "resolv.conf".text = ''${lib.strings.concatLines (lib.lists.forEach config.networking.nameservers (
+          x: ''
+            nameserver ${x}
+          ''
+        ))}'';
+      "udhcpc/udhcpc.conf".text = "${
+        if config.networking.dhcp.overrideNameservers == false
+        then "RESOLV_CONF = no"
+        else "RESOLV_CONF = /etc/resolv.conf"
+      }";
+      "nsswitch.conf".text = ''
+        hosts:     files dns
+        networks:  files dns
+      '';
+
+      "network/interfaces".text = ''
+        auto lo
+        iface lo inet loopback
+        ${lib.strings.concatLines (lib.lists.forEach config.networking.interfaces (
+          x: ''
+            auto ${x.name}
+            ${
+              if x.dhcp == true || x.dhcp == null && x.ipv4.address == null
+              then ''
+                iface ${x.name}
+                  use dhcp
+                  dhcp-program dhcpcd
+              ''
+              else ''
+                iface ${x.name} inet static
+                  address ${x.ipv4.address}
+                  gateway ${x.ipv4.gateway}
+              ''
+            }
+            ${
+              if x.slaac == true || x.slaac == null && x.ipv6.address == null
+              then "iface ${x.name} inet6 auto"
+              else ''
+                iface ${x.name} inet6 static
+                  address ${x.ipv6.address}
+                  gateway ${x.ipv6.gateway}
+              ''
+            }
+          ''
+        ))}
+      '';
     };
   };
 }

--- a/micros/modules/profiles/virtualization/iso-image.nix
+++ b/micros/modules/profiles/virtualization/iso-image.nix
@@ -107,7 +107,7 @@
     "virtio_scsi"
     "virtio_balloon"
     "virtio_console"
-
+    "af_packet"
     # VMware support.
     "mptspi"
     "vmxnet3"
@@ -129,4 +129,9 @@
     neededForBoot = true;
   };
   services.getty.enable = true;
+  networking.interfaces = [
+    {
+      name = "eth0";
+    }
+  ];
 }

--- a/micros/modules/profiles/virtualization/qemu-guest.nix
+++ b/micros/modules/profiles/virtualization/qemu-guest.nix
@@ -1,5 +1,5 @@
 {
-  boot.initrd.kernelModules = ["virtio" "virtio_pci" "virtio_net" "virtio_rng" "virtio_blk" "virtio_console"];
+  boot.initrd.kernelModules = ["virtio" "virtio_pci" "virtio_net" "virtio_rng" "virtio_blk" "virtio_console" "af_packet"];
   fileSystems."/" = {
     device = "none";
     fsType = "tmpfs";
@@ -11,4 +11,9 @@
     neededForBoot = true;
   };
   services.getty.enable = true;
+  networking.interfaces = [
+    {
+      name = "eth0";
+    }
+  ];
 }

--- a/micros/modules/system/activation.nix
+++ b/micros/modules/system/activation.nix
@@ -30,5 +30,8 @@ in {
     chmod 0555 /var/empty
     chown root:root /var/empty
     ${pkgs.e2fsprogs}/bin/chattr -f +i /var/empty || true
+    # Link /var/run to tmpfs
+    ln -sfn /run /var/run
+    hostname -F /etc/hostname
   '';
 }

--- a/micros/modules/system/boot/runit/stages.nix
+++ b/micros/modules/system/boot/runit/stages.nix
@@ -40,24 +40,12 @@ in {
           # If /etc/ssh is missing, create it.
           [ ! -d /etc/ssh ] && mkdir -p /etc/ssh
 
-          ${optionalString config.not-os.simpleStaticIp.enable ''
-            # Assign a static IP to a given interface with a set IP, route and gateway.
-            ip addr add ${cfg.simpleStaticIp.address} dev ${cfg.simpleStaticIp.interface}
-            ip link set ${cfg.simpleStaticIp.interface} up
-            ip route add ${cfg.simpleStaticIp.route} dev ${cfg.simpleStaticIp.interface}
-            ip route add default via ${cfg.simpleStaticIp.gateway} dev ${cfg.simpleStaticIp.interface}
-          ''}
-
           # Link /bin/sh from environment.binsh, defaults to ash from buxybox.
           mkdir /bin
           ln -s ${config.environment.binsh} /bin/sh
 
-          ${optionalString config.networking.dhcp.enable ''
-            # Network discovery
-            mkdir -p /var/db/dhcpcd /var/run/dhcpcd
-            touch /etc/dhcpcd.conf
-            ${pkgs.dhcpcd}/sbin/dhcpcd --oneshot
-          ''}
+          # Bring network interfaces up
+          ifup -v -a -E ${(pkgs.callPackage ../../../../../pkgs/ifupdown-ng.nix {})}/usr/libexec/ifupdown-ng
 
           ${optionalString (config.networking.timeServers != []) ''
             # Configure timeservers

--- a/micros/modules/system/boot/stage-1-init.sh
+++ b/micros/modules/system/boot/stage-1-init.sh
@@ -318,6 +318,7 @@ mount --move /proc $targetRoot/proc
 mount --move /sys $targetRoot/sys
 mount --move /dev $targetRoot/dev
 mount --move /run $targetRoot/run
+
 # Start stage 2. `switch_root' deletes all files in the ramfs on the
 # current root. The path has to be valid in the chroot not outside.
 

--- a/micros/modules/system/boot/stage-1.nix
+++ b/micros/modules/system/boot/stage-1.nix
@@ -32,6 +32,7 @@
     "/var/log"
     "/var/lib"
     "/var/lib/nixos"
+    "/var/run"
     "/etc"
     "/usr"
   ];

--- a/pkgs/ifupdown-fix-path.patch
+++ b/pkgs/ifupdown-fix-path.patch
@@ -1,0 +1,104 @@
+diff --git a/executor-scripts/linux/dhcp b/executor-scripts/linux/dhcp
+index aff637b..feb6673 100755
+--- a/executor-scripts/linux/dhcp
++++ b/executor-scripts/linux/dhcp
+@@ -21,13 +21,13 @@ start() {
+ 		[ -n "$IF_DHCP_LEASETIME" ] && optargs="$optargs -l $IF_DHCP_LEASETIME"
+ 		[ -n "$IF_DHCP_CONFIG" ] && optargs="$optargs -f $IF_DHCP_CONFIG"
+ 		[ -n "$IF_DHCP_SCRIPT" ] && optargs="$optargs -c $IF_DHCP_SCRIPT"
+-		${MOCK} /sbin/dhcpcd $optargs $IFACE
++		${MOCK} dhcpcd $optargs $IFACE
+ 		;;
+ 	dhclient)
+ 		optargs=$(eval echo $IF_DHCP_OPTS)
+ 		[ -n "$IF_DHCP_CONFIG" ] && optargs="$optargs -cf $IF_DHCP_CONFIG"
+ 		[ -n "$IF_DHCP_SCRIPT" ] && optargs="$optargs -sf $IF_DHCP_SCRIPT"
+-		${MOCK} /usr/sbin/dhclient -pf /var/run/dhclient.$IFACE.pid $optargs $IFACE
++		${MOCK} dhclient -pf /var/run/dhclient.$IFACE.pid $optargs $IFACE
+ 		;;
+ 	udhcpc)
+ 		optargs=$(eval echo $IF_UDHCPC_OPTS $IF_DHCP_OPTS)
+@@ -36,7 +36,7 @@ start() {
+ 		[ -n "$IF_DHCP_CLIENT_ID" ] && optargs="$optargs -x 0x3d:${IF_DHCP_CLIENT_ID}"
+ 		[ -n "$IF_DHCP_LEASETIME" ] && optargs="$optargs -x lease:${IF_DHCP_LEASETIME}"
+ 		[ -n "$IF_DHCP_SCRIPT" ] && optargs="$optargs -s $IF_DHCP_SCRIPT"
+-		${MOCK} /sbin/udhcpc -b -R -p /var/run/udhcpc.$IFACE.pid -i $IFACE $optargs
++		${MOCK} udhcpc -b -R -p /var/run/udhcpc.$IFACE.pid -i $IFACE $optargs
+ 		;;
+ 	*)
+ 		;;
+diff --git a/executor-scripts/linux/vrf b/executor-scripts/linux/vrf
+index ac3668a..3803996 100755
+--- a/executor-scripts/linux/vrf
++++ b/executor-scripts/linux/vrf
+@@ -11,19 +11,19 @@ kernel_version_48() {
+ }
+ 
+ handle_init() {
+-	${MOCK} /sbin/ip link $1 $IFACE type vrf table $IF_VRF_TABLE
++	${MOCK} ip link $1 $IFACE type vrf table $IF_VRF_TABLE
+ 	if kernel_version_48; then
+-		${MOCK} /sbin/ip rule $1 iif $IFACE table $IF_VRF_TABLE
+-		${MOCK} /sbin/ip rule $1 oif $IFACE table $IF_VRF_TABLE
++		${MOCK} ip rule $1 iif $IFACE table $IF_VRF_TABLE
++		${MOCK} ip rule $1 oif $IFACE table $IF_VRF_TABLE
+ 	fi
+ }
+ 
+ handle_member() {
+-	${MOCK} /sbin/ip link set $IFACE master $IF_VRF_MEMBER
++	${MOCK} ip link set $IFACE master $IF_VRF_MEMBER
+ }
+ 
+ handle_member_off() {
+-	${MOCK} /sbin/ip link set $IFACE nomaster
++	${MOCK} ip link set $IFACE nomaster
+ }
+ 
+ [ -n "$VERBOSE" ] && set -x
+diff --git a/executor-scripts/linux/wifi b/executor-scripts/linux/wifi
+index 398c2ac..8cce340 100755
+--- a/executor-scripts/linux/wifi
++++ b/executor-scripts/linux/wifi
+@@ -46,7 +46,7 @@ generate_config() {
+ 	[ -z "$IF_WIFI_SSID" ] && die "wifi-ssid not set"
+ 	[ -z "$IF_WIFI_PSK" ] && die "wifi-psk not set"
+ 
+-	/sbin/wpa_passphrase "$IF_WIFI_SSID" "$IF_WIFI_PSK" >$WIFI_CONFIG_PATH
++	wpa_passphrase "$IF_WIFI_SSID" "$IF_WIFI_PSK" >$WIFI_CONFIG_PATH
+ 
+ 	[ ! -e "$WIFI_CONFIG_PATH" ] && die "failed to write temporary config: $WIFI_CONFIG_PATH"
+ }
+@@ -66,9 +66,9 @@ start() {
+ 		# If there is no config file located at $WIFI_CONFIG_PATH, generate one.
+ 		[ ! -e "$WIFI_CONFIG_PATH" ] && generate_config
+ 
+-		/sbin/wpa_supplicant $WPA_SUPPLICANT_OPTS
++		wpa_supplicant $WPA_SUPPLICANT_OPTS
+ 	else
+-		/usr/sbin/iwconfig $IFACE essid -- "$IF_WIFI_SSID" ap any
++		iwconfig $IFACE essid -- "$IF_WIFI_SSID" ap any
+ 	fi
+ }
+ 
+@@ -102,7 +102,7 @@ stop() {
+ 	if use_supplicant; then
+ 		stop_wpa_supplicant
+ 	else
+-		/usr/sbin/iwconfig $IFACE essid any
++		iwconfig $IFACE essid any
+ 	fi
+ }
+ 
+diff --git a/libifupdown/lifecycle.c b/libifupdown/lifecycle.c
+index 8bc9526..998c8ee 100644
+--- a/libifupdown/lifecycle.c
++++ b/libifupdown/lifecycle.c
+@@ -166,7 +166,7 @@ build_environment(char **envp[], const struct lif_execute_opts *opts, const stru
+ 
+ 	/* Use sane defaults for PATH */
+ 	if (geteuid() == 0)
+-		lif_environment_push(envp, "PATH", _PATH_STDPATH);
++		lif_environment_push(envp, "PATH", getenv("PATH"));
+ 	else
+ 		lif_environment_push(envp, "PATH", _PATH_DEFPATH);

--- a/pkgs/ifupdown-ng.nix
+++ b/pkgs/ifupdown-ng.nix
@@ -1,0 +1,30 @@
+{
+  fetchFromGitHub,
+  stdenv,
+  libbsd,
+  iproute2,
+  ...
+}:
+stdenv.mkDerivation {
+  pname = "ifupdown-ng";
+  version = "0-unstable-2025-05-31";
+
+  src = fetchFromGitHub {
+    owner = "ifupdown-ng";
+    repo = "ifupdown-ng";
+    rev = "e305296b3d23e56bba92c504e030d8e4b91db403";
+    hash = "sha256-psA7HxDS9asUan7wKVeWB9fbL+da+s49wRvTqRQnwP0=";
+  };
+  buildInputs = [libbsd iproute2];
+  patches = [
+    ./ifupdown-fix-path.patch
+  ];
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    ${builtins.concatStringsSep "\n" (map (x: "install -D -m755 ${x} $out/bin") ["ifupdown" "ifup" "ifdown" "ifquery" "ifparse" "ifctrstat"])}
+    mkdir -p $out/usr/libexec/ifupdown-ng
+    install -D -m755 executor-scripts/linux/* $out/usr/libexec/ifupdown-ng/
+    runHook postInstall
+  '';
+}


### PR DESCRIPTION
Adds a basic networking implementation using ifupdown-ng to manage interfaces. 
Currently, it:
- Supports both IPV4 and IPV6
- Supports static networking with one IP address and a gateway
- Supports DHCP and SLAAC for automatic configuration
- Supports hostname configuration
- Supports nameserver configuration

TODO:
- Allow automatic configuration of interfaces without explicit configuration
- Allow multiple IPs per interface
- Allow more complex network configuration with vnets, VPNs, and WiFi