### PR TITLE
Fix modprobe support by adding kernel-modules to toplevel

### DIFF
--- a/micros/modules/config/system-path.nix
+++ b/micros/modules/config/system-path.nix
@@ -18,6 +18,7 @@ let
     pkgs.iputils
     pkgs.procps
     pkgs.bashInteractive
+    pkgs.kmod
     pkgs.dhcpcd
     (pkgs.callPackage ../../../pkgs/ifupdown-ng.nix {})
   ];

--- a/micros/modules/system/activation.nix
+++ b/micros/modules/system/activation.nix
@@ -22,6 +22,8 @@ in {
     # Various log/runtime directories.
     mkdir -p /var/tmp
     chmod 1777 /var/tmp
+    mkdir -p /var/lib
+    chmod 1777 /var/lib
     # Empty, immutable home directory of many system accounts.
     mkdir -p /var/empty
     # Make sure it's really empty

--- a/micros/modules/system/boot/stage-1-init.sh
+++ b/micros/modules/system/boot/stage-1-init.sh
@@ -254,7 +254,7 @@ done
 if test -n "$debug1mounts"; then fail; fi
 
 # Restore /proc/sys/kernel/modprobe to its original value.
-echo /sbin/modprobe >/proc/sys/kernel/modprobe
+echo @modprobe@ >/proc/sys/kernel/modprobe
 
 # Defines fail function, giving user a shell in case of emergency.
 

--- a/micros/modules/system/boot/stage-1.nix
+++ b/micros/modules/system/boot/stage-1.nix
@@ -167,7 +167,7 @@
 
     replacements = {
       shell = "${extraUtils}/bin/ash";
-
+      modprobe = "${pkgs.kmod}/bin/modprobe";
       # Expects $targetRoot to be set in the stage-1 script.
       mountScript = ''
         ${config.not-os.preMount}

--- a/micros/modules/system/build.nix
+++ b/micros/modules/system/build.nix
@@ -6,6 +6,7 @@
 }: let
   inherit (lib) mkOption;
   inherit (lib) types;
+  inherit (config.boot.kernelPackages) kernel;
 in {
   options = {
     system = {
@@ -305,6 +306,7 @@ in {
           cp ${config.system.build.bootStage2} $out/init
           substituteInPlace $out/init --subst-var-by systemConfig $out
           ln -s ${config.system.path} $out/sw
+          ln -s ${kernel} $out/kernel-modules
           echo "$activationScript" > $out/activate
           substituteInPlace $out/activate --subst-var out
           chmod u+x $out/activate


### PR DESCRIPTION
Fixes issues with modprobe which caused applications which needed specific kernel modules (especially surrounding networking) to not function properly.