### PR TITLE
Fix rngd and sshd services

### DIFF
--- a/micros/modules/services/rngd.nix
+++ b/micros/modules/services/rngd.nix
@@ -17,7 +17,7 @@ in {
 
   config = mkIf cfg.enable {
     runit.services = {
-      nix-daemon = {
+      rngd = {
         runScript = ''
           #!${pkgs.runtimeShell}
           export PATH=$PATH:${lib.makeBinPath cfg.package}


### PR DESCRIPTION
Fixes 2 bugs in service configuration:
1. rngd used the name nix-daemon instead of rngd, overwriting nix-daemon
2. sshd did not generate host keys as intended, and due to how sshd works, the service attempts to spawn the daemon multiple times. This behavior was caused by sshd exiting after starting, causing the service to restart.