### PR TITLE
foundational init agnosticism

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,10 @@ MicrOS is a small, experimental operating system designed for embedded
 situations. It is based heavily on NixOS, but compiles down to a microscopic
 kernel[^1], an initrd and a ~50mb squashfs.
 
-[Runit](https://smarden.org/runit/) is used instead of systemd, with some degree
-of abstraction over services. This is not as robust as NixOS systemd module, nor
-is it in any way portable (i.e., additional init systems are not yet possible)
-but it results in a small and fast image for low-resource scenarios, e.g.,
-embedded development.
+[Runit](https://smarden.org/runit/) is the default init backend, with a small
+init-agnostic service interface layered over it. This is not as robust as the
+NixOS systemd module, but it results in a small and fast image for low-resource
+scenarios, e.g., embedded development.
 
 ## Why
 
@@ -52,6 +51,12 @@ lib.microsSystem {
 Above configuration enough to construct a basic system. You may build different
 components of the configuration, available under `config.system.build` to create
 different build artifacts for different workflows.
+
+## Init systems
+
+MicrOS hands PID 1 off to the selected init backend after stage 2 activation.
+`runit` is the default backend. Service modules should use `micros.services`;
+the backend translates those services into whatever layout it needs.
 
 ## Contributing
 

--- a/flake.nix
+++ b/flake.nix
@@ -26,45 +26,50 @@
     # specific systems.
     # hydraJobs = self.packages;
 
-    packages = forSupportedSystems (system: {
-      iso =
-        (lib.microsSystem
-          {
+    packages = forSupportedSystems (system:
+      {
+        qemu =
+          (lib.microsSystem {
             specialArgs = {inherit inputs lib;};
             modules = [
-              ./micros/modules/profiles/virtualization/iso-image.nix
+              ./micros/modules/profiles/virtualization/qemu-guest.nix
 
+              {
+                nixpkgs.hostPlatform = {inherit system;};
+              }
+            ];
+          }).config.system.build.runvm;
+      }
+      // lib.optionalAttrs (system == "x86_64-linux") {
+        lxc =
+          (lib.microsSystem {
+            specialArgs = {inherit inputs lib;};
+            modules = [
+              ./micros/modules/profiles/virtualization/lxc-profile.nix
               {
                 nixpkgs.hostPlatform = {
                   inherit system;
+                  config = "x86_64-unknown-linux-musl";
                 };
               }
             ];
-          }).config.system.build.image;
-      qemu =
-        (lib.microsSystem {
-          specialArgs = {inherit inputs lib;};
-          modules = [
-            ./micros/modules/profiles/virtualization/qemu-guest.nix
+          }).config.system.build.ociImage;
 
+        iso =
+          (lib.microsSystem
             {
-              nixpkgs.hostPlatform = {inherit system;};
-            }
-          ];
-        }).config.system.build.runvm;
-      lxc = lib.microsSystem {
-        specialArgs = {inherit inputs lib;};
-        modules = [
-          ./micros/modules/profiles/virtualization/lxc-profile.nix
-          {
-            nixpkgs.hostPlatform = {
-              inherit system;
-              config = "x86_64-unknown-linux-musl";
-            };
-          }
-        ];
-      };
-    });
+              specialArgs = {inherit inputs lib;};
+              modules = [
+                ./micros/modules/profiles/virtualization/iso-image.nix
+
+                {
+                  nixpkgs.hostPlatform = {
+                    inherit system;
+                  };
+                }
+              ];
+            }).config.system.build.image;
+      });
 
     legacyPackages = forSupportedSystems (system: let
       pkgs = pkgsFor system;

--- a/micros/modules/all-modules.nix
+++ b/micros/modules/all-modules.nix
@@ -10,6 +10,7 @@
   ./system/boot/runit/stages.nix
   ./system/boot/containers.nix
   ./system/boot/getty.nix
+  ./system/boot/init.nix
   ./system/boot/kernel.nix
   ./system/boot/stage-1.nix
   ./system/boot/stage-2.nix
@@ -18,6 +19,7 @@
   ./system/build.nix
   ./system/etc-setup.nix
   ./system/name.nix
+  ./system/services.nix
 
   ./services/nix-daemon.nix
   ./services/getty.nix

--- a/micros/modules/config/users.nix
+++ b/micros/modules/config/users.nix
@@ -74,14 +74,14 @@ in {
       };
     };
 
-    runit.services = {
+    micros.services = {
       user-init = {
-        runScript = ''
+        type = "oneshot";
+        startScript = ''
           #!${pkgs.busybox}/bin/ash
           # Make home directories
           ${lib.concatLines (builtins.attrValues (builtins.mapAttrs (name: value: "mkdir -p ${value.home}") config.users))}
           ${lib.concatLines (builtins.attrValues (builtins.mapAttrs (name: value: "chown ${toString value.uid}:${toString value.gid} -f -R ${value.home}") config.users))}
-          exec ${pkgs.runit}/bin/sv pause /etc/service/user-init
         '';
       };
     };

--- a/micros/modules/networking/nftables.nix
+++ b/micros/modules/networking/nftables.nix
@@ -270,7 +270,7 @@ in {
     # boot.blacklistedKernelModules = ["ip_tables"];
     environment.systemPackages = [pkgs.nftables];
     networking.nftables.checkRuleset = ! (pkgs.stdenv.hostPlatform.isMusl);
-    runit.services = {
+    micros.services = {
       nftables = let
         enabledTables = lib.filterAttrs (_: table: table.enable) cfg.tables;
         deletionsScript = pkgs.writeScript "nftables-deletions" ''
@@ -344,13 +344,13 @@ in {
         };
       in {
         name = "nftables";
-        runScript = ''
+        type = "oneshot";
+        startScript = ''
           #!${pkgs.busybox}/bin/ash
           mkdir /var/lib/nftables
           ${ensureDeletions}
           ${rulesScript}
           ${saveDeletionsScript}
-          exec sv down /etc/service/nftables
         '';
       };
     };

--- a/micros/modules/services/getty.nix
+++ b/micros/modules/services/getty.nix
@@ -16,9 +16,9 @@ in {
 
   config = mkIf cfg.enable {
     security.pam.enable = true;
-    runit.services = {
+    micros.services = {
       getty = {
-        runScript = ''
+        startScript = ''
           #!${pkgs.busybox}/bin/ash
           echo "Starting getty"
           ${pkgs.busybox}/bin/busybox getty -l ${pkgs.shadow}/bin/login 0 /dev/ttyS0

--- a/micros/modules/services/nix-daemon.nix
+++ b/micros/modules/services/nix-daemon.nix
@@ -4,7 +4,7 @@
   lib,
   ...
 }: let
-  inherit (lib) mkIf mkOption mkPackageOption mkEnableOption;
+  inherit (lib) mkIf mkPackageOption mkEnableOption;
 
   cfg = config.services.nix-daemon;
 in {
@@ -16,9 +16,9 @@ in {
   };
 
   config = mkIf cfg.enable {
-    runit.services = {
+    micros.services = {
       nix-daemon = {
-        runScript = ''
+        startScript = ''
           #!${pkgs.busybox}/bin/ash
 
           echo "Starting nix-daemon"

--- a/micros/modules/services/rngd.nix
+++ b/micros/modules/services/rngd.nix
@@ -4,9 +4,9 @@
   lib,
   ...
 }: let
-  inherit (lib) mkIf mkOption mkPackageOption mkEnableOption;
+  inherit (lib) mkIf mkPackageOption mkEnableOption;
 
-  cfg = config.services.nix-daemon;
+  cfg = config.services.rngd;
 in {
   options = {
     services.rngd = {
@@ -16,9 +16,9 @@ in {
   };
 
   config = mkIf cfg.enable {
-    runit.services = {
+    micros.services = {
       rngd = {
-        runScript = ''
+        startScript = ''
           #!${pkgs.busybox}/bin/ash
           export PATH=$PATH:${lib.makeBinPath cfg.package}
 

--- a/micros/modules/services/sshd.nix
+++ b/micros/modules/services/sshd.nix
@@ -66,9 +66,9 @@ in {
   };
 
   config = mkIf cfg.enable {
-    runit.services = {
+    micros.services = {
       sshd = {
-        runScript = ''
+        startScript = ''
           #!${pkgs.busybox}/bin/ash
           echo "Generating Host Keys"
           ${lib.strings.concatLines (

--- a/micros/modules/system/boot/init.nix
+++ b/micros/modules/system/boot/init.nix
@@ -1,0 +1,59 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}: let
+  inherit (lib) mkOption;
+  inherit (lib) types;
+in {
+  options = {
+    boot.init = {
+      system = mkOption {
+        type = types.str;
+        default = "runit";
+        description = ''
+          Init backend used after stage-2 activation has completed.
+        '';
+      };
+
+      executable = mkOption {
+        type = with types; either path str;
+        default = "${pkgs.runit}/bin/runit";
+        defaultText = lib.literalExpression ''"''${pkgs.runit}/bin/runit"'';
+        description = ''
+          Executable that stage 2 will hand off to as PID 1.
+        '';
+      };
+
+      stage2Path = mkOption {
+        type = types.str;
+        default = "/run/booted-system/sw/bin";
+        description = ''
+          PATH value used by stage 2 before handing off to the init backend.
+        '';
+      };
+
+      backendAvailable = mkOption {
+        type = types.bool;
+        default = false;
+        internal = true;
+        description = ''
+          Whether a module for the selected init backend is available.
+        '';
+      };
+    };
+  };
+
+  config = {
+    assertions = [
+      {
+        assertion = config.boot.init.backendAvailable;
+        message = ''
+          boot.init.system is set to "${config.boot.init.system}", but MicrOS
+          does not provide that init backend.
+        '';
+      }
+    ];
+  };
+}

--- a/micros/modules/system/boot/runit/services.nix
+++ b/micros/modules/system/boot/runit/services.nix
@@ -68,6 +68,22 @@
       {name = mkDefault name;}
     ];
   });
+
+  genericServices = lib.mapAttrs (_: value: {
+    inherit (value) enable name finishScript confScript;
+    runScript =
+      if value.startScript == null
+      then null
+      else if value.type == "oneshot"
+      then ''
+        ${value.startScript}
+        # Runit will restart an exited run script unless the service is marked down.
+        exec ${pkgs.runit}/bin/sv down /etc/service/${value.name}
+      ''
+      else value.startScript;
+  }) config.micros.services;
+
+  runitServices = genericServices // config.runit.services;
 in {
   options = {
     runit.services = mkOption {
@@ -76,38 +92,52 @@ in {
     };
   };
 
-  config = {
-    environment.etc = mkMerge [
-      (mapAttrs' (name: value: {
-          inherit (value) enable;
-          name = "service/${name}/run";
-          value = mkIf (value.runScript != null) {
-            text = ''${value.runScript}'';
-            mode = "0755";
-          };
-        })
-        config.runit.services)
+  config = mkMerge [
+    {
+      assertions = [
+        {
+          assertion = config.boot.init.system == "runit" || config.runit.services == {};
+          message = ''
+            runit.services is set, but boot.init.system is "${config.boot.init.system}".
+            Use micros.services for backend-agnostic services or select the runit backend.
+          '';
+        }
+      ];
+    }
 
-      (mapAttrs' (name: value: {
-          inherit (value) enable;
-          name = "service/${name}/finish";
+    (mkIf (config.boot.init.system == "runit") {
+      environment.etc = mkMerge [
+        (mapAttrs' (name: value: {
+            inherit (value) enable;
+            name = "service/${name}/run";
+            value = mkIf (value.runScript != null) {
+              text = ''${value.runScript}'';
+              mode = "0755";
+            };
+          })
+          runitServices)
 
-          value = mkIf (value.finishScript != null) {
-            text = ''${value.finishScript}'';
-            mode = "0755";
-          };
-        })
-        config.runit.services)
+        (mapAttrs' (name: value: {
+            inherit (value) enable;
+            name = "service/${name}/finish";
 
-      (mapAttrs' (name: value: {
-          inherit (value) enable;
-          name = "service/${name}/conf";
-          value = mkIf (value.confScript != null) {
-            text = ''${value.confScript}'';
-            mode = "0755";
-          };
-        })
-        config.runit.services)
-    ];
-  };
+            value = mkIf (value.finishScript != null) {
+              text = ''${value.finishScript}'';
+              mode = "0755";
+            };
+          })
+          runitServices)
+
+        (mapAttrs' (name: value: {
+            inherit (value) enable;
+            name = "service/${name}/conf";
+            value = mkIf (value.confScript != null) {
+              text = ''${value.confScript}'';
+              mode = "0755";
+            };
+          })
+          runitServices)
+      ];
+    })
+  ];
 }

--- a/micros/modules/system/boot/runit/stages.nix
+++ b/micros/modules/system/boot/runit/stages.nix
@@ -5,7 +5,7 @@
   ...
 }: let
   inherit (lib) mkOption mkPackageOption;
-  inherit (lib) optionalString;
+  inherit (lib) mkIf optionalString;
   inherit (lib) types;
 
   runit-compat = pkgs.symlinkJoin {
@@ -115,7 +115,8 @@ in {
     };
   };
 
-  config = {
+  config = mkIf (config.boot.init.system == "runit") {
+    boot.init.backendAvailable = true;
     environment.systemPackages = [runit-compat];
     environment.etc = {
       # Runit has three stages: booting, running and shutdown in runit/ 1,2 and 3 respectively.

--- a/micros/modules/system/boot/stage-2.nix
+++ b/micros/modules/system/boot/stage-2.nix
@@ -2,7 +2,6 @@
   config,
   pkgs,
   lib,
-  inputs,
   ...
 }: {
   config = {
@@ -12,8 +11,8 @@
       text = ''
         #! ${pkgs.busybox}/bin/ash
         export PATH="${lib.makeBinPath [pkgs.busybox pkgs.nixos-core]}"
-        export SYSTEMD_EXECUTABLE=${pkgs.runit}/bin/runit
-        export STAGE2_PATH=/run/booted-system/sw/bin
+        export SYSTEMD_EXECUTABLE=${lib.escapeShellArg config.boot.init.executable}
+        export STAGE2_PATH=${lib.escapeShellArg config.boot.init.stage2Path}
         REPLACE_WITH_CONTAINER
         exec ${pkgs.nixos-core}/bin/nixos-core stage-2-init --system-config REPLACE_WITH_TOPLEVEL
       '';

--- a/micros/modules/system/services.nix
+++ b/micros/modules/system/services.nix
@@ -1,0 +1,75 @@
+{
+  config,
+  lib,
+  ...
+}: let
+  inherit (lib) mkDefault mkEnableOption mkMerge mkOption;
+  inherit (lib) types;
+
+  serviceOpts = types.submodule ({
+    name,
+    config,
+    ...
+  }: {
+    options = {
+      enable =
+        mkEnableOption ''
+          Whether to enable this service.
+        ''
+        // {default = true;};
+
+      name = mkOption {
+        type = types.str;
+        description = ''
+          Service name used by the selected init backend.
+        '';
+      };
+
+      type = mkOption {
+        type = types.enum ["longrun" "oneshot"];
+        default = "longrun";
+        description = ''
+          Whether this service should be supervised continuously or run once.
+        '';
+      };
+
+      startScript = mkOption {
+        type = types.nullOr types.lines;
+        default = null;
+        description = ''
+          Shell script used to start the service.
+        '';
+      };
+
+      finishScript = mkOption {
+        type = types.nullOr types.lines;
+        default = null;
+        description = ''
+          Optional shell script run by init backends that support service exit hooks.
+        '';
+      };
+
+      confScript = mkOption {
+        type = types.nullOr types.lines;
+        default = null;
+        description = ''
+          Optional shell fragment available to init backends that support service configuration files.
+        '';
+      };
+    };
+
+    config = mkMerge [
+      {name = mkDefault name;}
+    ];
+  });
+in {
+  options = {
+    micros.services = mkOption {
+      type = types.attrsOf serviceOpts;
+      default = {};
+      description = ''
+        Init-backend-agnostic service definitions.
+      '';
+    };
+  };
+}


### PR DESCRIPTION
- adds generic init options (system/boot/{init, stage2}.nix)
- refactors stage-2 handoff to use boot.init.executable
- moves runit stage2+services behind `boot.init.system == "runit"`
- adds backend-agnostic micros.services (system/services.nix)
- adds a runit backend to micros.services
- adds a poc scripted backend in system/boot/scripted/init.nix
- adds documentation
- bonus round: fixes rngd bug where it read services.nix-daemon instead of services.rngd

fixes: #2