### PR TITLE
docs: enrich contents; fix terminology and wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
 # MicrOS
 
-MicrOS is a small, experimental operating system designed for embedded
-situations. It is based heavily on NixOS, but compiles down to a microscopic
-kernel[^1], an initrd and a ~50mb squashfs.
+Small, experimental operating system designed for embedded and containerized
+situations. MicrOS is based _heavily_ on NixOS, but compiles down to a
+microscopic kernel[^1], an initrd, a ~50mb squashfs,
 
+This is also our experiment in init-agnostic NixOS.
 [Runit](https://smarden.org/runit/) is the default init backend, with a small
 init-agnostic service interface layered over it. This is not as robust as the
 NixOS systemd module, but it results in a small and fast image for low-resource
-scenarios, e.g., embedded development.
+scenarios, e.g., embedded development and service containers.
 
-## Why
+## Motivation
 
 NixOS is great, it fits under most use-cases and it is extremely flexible on
 what you might use it for. Unfortunately for us, it is quite _large_ even after
@@ -50,9 +51,11 @@ lib.microsSystem {
 
 Above configuration enough to construct a basic system. You may build different
 components of the configuration, available under `config.system.build` to create
-different build artifacts for different workflows.
+different build artifacts for different workflows. Please see
+[our documentation](https://github.com/cleverca22/not-os) for more details and
+module system options.
 
-## Init systems
+## Init Systems
 
 MicrOS hands PID 1 off to the selected init backend after stage 2 activation.
 `runit` is the default backend. Service modules should use `micros.services`;
@@ -73,24 +76,25 @@ additional services that could be upstreamed to MicrOS.
 
 [not-os]: https://github.com/cleverca22/not-os
 
+MicrOS is MIT licensed as a result of its status as a **hard**-fork of [not-os]
+and our tendency to borrow modules from Nixpkgs, both of which are MIT licensed.
+Any and all work here is available under the MIT license, following upstream.
+Please support the original author and contributors.
+
 > [!NOTE]
-> Work here is based _heavily_ on the awesome [not-os]. I worked on something
-> similar until I realized I was duplicating effort for no reason. This
-> repository diverges (and will continue to diverge from not-os) in terms of
-> module structure, coding conventions and goals on what should and should not
-> be provided. In addition to the aggressive repository restructure, I will be
-> working to provide more _idiomatic_ Nix code that follows best practices and
-> focuses on purity.
+> Work here is based _heavily_ on the awesome [not-os]. I (@notashelf) worked on
+> something similar until I realized I was duplicating effort for no reason.
+> This repository diverges (and will continue to diverge from not-os) in terms
+> of module structure, coding conventions and goals on what should and should
+> not be provided. In addition to the aggressive repository restructure, I will
+> be working to provide more _idiomatic_ Nix code that follows best practices
+> and focuses on purity.
 
-MicrOS is a _soft_-fork of not-os, plain and simple. Any and all work here is
-available under the MIT license, following upstream. I do not make any claims on
-the code provided here. Please support the original author and contributors.
-
-The nature of MicrOS does not quite allow for a dependency on nixpkgs due to its
-tight integration with systemd. Although, we borrow modules from nixpkgs at
-times to avoid duplicating work, or to avoid reinventing the wheel as as square.
-A copyright notice is hereby provided that _some_ modules in MicrOS are directly
-copied from nixpkgs, also available under the MIT license.
+The nature of MicrOS does not quite allow for a _direct_ dependency on Nixpkgs
+due to its tight integration with Systemd. Although, we borrow modules from
+nixpkgs at times to avoid duplicating work, or to avoid reinventing the wheel as
+as square. A copyright notice is hereby provided that _some_ modules in MicrOS
+are directly copied from nixpkgs, also available under the MIT license.
 
 Please see [LICENSE](LICENSE.md) for details.
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ lib.microsSystem {
 Above configuration enough to construct a basic system. You may build different
 components of the configuration, available under `config.system.build` to create
 different build artifacts for different workflows. Please see
-[our documentation](https://github.com/cleverca22/not-os) for more details and
+[our documentation](https://micros.snugnug.org) for more details and
 module system options.
 
 ## Init Systems

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,18 +1,18 @@
 # Getting Started
 
-This document is a basic guide for creating a micros image.
+This document is a basic guide for creating a MicrOS image.
 
 ## Prerequisites
 
 To follow this guide, you require the following software:
 
-- Nix package manager
-- A text editor
+- The [Nix build tool](https://nixos.org)
+- A text editor of your choosing
 
-Additionally, while this guide can be followed with or without nix flakes,
-testing is primarily done with nix flakes, and commands given use nix flakes. It
-is recommended that flakes are enabled for users who are unfamiliar with the nix
-language.
+Additionally, while this guide _could_ be followed with or without the
+experimental flakes feature enabled, testing is done primarily with Nix flakes,
+and the example commands given use Nix flakes. It is recommended that flakes are
+enabled for users who are unfamiliar with the Nix language.
 
 ```{=include=} chapters
 getting-started/creating-config.md

--- a/docs/getting-started/creating-config.md
+++ b/docs/getting-started/creating-config.md
@@ -1,32 +1,51 @@
-# Starting a configuration
+# Starting a MicrOS Configuration
 
-Micros images are configured using the nix language. To start a micros
-configuration, create a folder and run
-`nix flake init -t github:snugnug/micros`. This creates a nix flake with a basic
-micros configuration, with the files `flake.nix`, `configuration.nix` and
-`hardware-configuration.nix`. Below are explanations of the three files.
+MicrOS images are configured using the Nix language. To start a MicrOS
+configuration, create a folder and run:
 
-Note: when modifying the flake, the names and structure of the files (outside of
-the `flake.nix` file) is unimportant, as long as the correct paths are included
-in the list of modules. Additionally, if git is being used in the configuration
-(which is recommended for configurations intended to be maintained and used over
-long periods), files which are not tracked by git will not be included in the
-system, and adding new files requires running `git add <file>` to track it in
-git.
+```bash
+# Create a flake with the default MicrOS template
+$ nix flake init -t github:snugnug/micros
+```
 
-## Flake.nix file
+This creates a Nix flake containing a MicrOS configuration, with the files
+`flake.nix`, `configuration.nix` and `hardware-configuration.nix`. Below are
+explanations of the three files.
 
-The `flake.nix` file includes the following content.
+> [!NOTE]
+> when modifying the flake, the names and structure of the files (outside of the
+> `flake.nix` file) is unimportant, as long as the correct paths are included in
+> the list of modules. Additionally, if git is being used in the configuration
+> (which is recommended for configurations intended to be maintained and used
+> over long periods), files which are not tracked by git will not be included in
+> the system, and adding new files requires running `git add <file>` to track it
+> in git.
+
+## `flake.nix`
+
+[relevant NixOS Wiki page]: https://wiki.nixos.org/wiki/Flakes
+
+> [!TIP]
+> An explanation of Nix flakes, their schema, and common fields can be found on
+> the [relevant NixOS Wiki page]. This guide assumes you are at least vaguely
+> familiar with the concept of Nix flakes.
+
+The `flake.nix`, i.e., your "configuration flake" typically includes the
+following content:
 
 ```nix
 {
   inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs?ref=nixos-unstable";
+
+    # The 'micros' input provides the custom library and module system
+    # required to build a MicrOS system.
     micros = {
       url = "github:snugnug/micros";
       inputs.nixpkgs.follows = "nixpkgs";
     };
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
   };
+
   outputs = {
     nixpkgs,
     micros,
@@ -46,6 +65,7 @@ The `flake.nix` file includes the following content.
           }
         ];
       }).config.system.build.image;
+    
     packages.x86_64-linux.container =
       (micros.lib.microsSystem {
         specialArgs = {inherit inputs;};
@@ -64,44 +84,66 @@ The `flake.nix` file includes the following content.
 }
 ```
 
-The inputs define git repos which are included into the flake. The basic
-configuration includes the 2 inputs, `nixpkgs` and `micros`. `nixpkgs` is the
-standard nix repository, which includes the majority of packages used by micros,
-along with extra functions which extend the nix language. `micros` includes all
-of the packages and functions which are used specifically by the micros distro.
-For the micros input, `input.nixpkgs.follows` tells the flake to use the user's
-version of `nixpkgs`, not the default one used by the `micros` flake. This
-ensures that package mismatches do not occur.
+The inputs define your sources, which will get copied to the Nix store while the
+flake is being evaluated. The basic/example configuration includes the 2 inputs:
+`nixpkgs` and `micros`.
 
-The outputs define the packages which the flake creates. The section
-`{nixpkgs, micros, ...} @ inputs:` tells the flake to pass the inputs into the
-packages, including them in the final built package.
-`packages.x86_64-linux.default` defines the image built by `nix build`, and
-`packages.x86_64-linux.container` defines the image built by
-`nix build .#container`. `micros.lib.microsSystem` is the function which creates
-the image, which includes 2 arguments. `modules` are the nix modules which are
-included into the final configuration. This can be in the form of files which
-include nix code, or nix code embedded directly. `specialArgs` defines the
-arguments passed into the modules. `config.system.build.image` is the specific
-output of a built `micros.lib.microsSystem` which includes an ISO image of the
-distro. Alternatively, if building a container, this can be replaced with
-`config.system.build.ociImage`, which creates an OCI-compatible image which can
+`nixpkgs` is the standard nix repository, which includes the majority of
+packages used by MicrOS, along with extra functions which extend the Nix
+language available under `nixpkgs.lib`. The `micros` input includes all of the
+packages and functions which are used specifically by MicrOS. For the `micros`
+input, `input.nixpkgs.follows` tells the flake to use the user's version of
+`nixpkgs`, not the default one used by the `micros` flake. This ensures that
+package mismatches do not occur, though, this might cause "cache misses" where a
+divergence in the source invalidates caching.
+
+In our case, outputs define the packages "exposed" by the flake. Typically
+flakes can provide more than just packages but for our purposes only `packages`
+are relevant. The argument set to the `outputs` section, e.g.,
+`{nixpkgs, micros, ...} @ inputs:` deconstructs `inputs` to make `nixpkgs` and
+`micros` inputs available individually instead of obtaining them through
+`inputs.<input>` each time. The use of `specialArgs = {inherit inputs;}` will
+pass the inputs reference into the MicrOS configuration, allowing you to
+reference your inputs throughout files imported by `microsSystem`.
+
+### Packages
+
+The example configuration has two distinct packages:
+
+- `packages.x86_64-linux.default` defines the image built by `nix build`,
+- `packages.x86_64-linux.container` defines the image built by
+  `nix build .#container`.
+
+`micros.lib.microsSystem` is the function that creates the system reference,
+which includes two arguments and exposes various derivations that we can use
+with `nix build`. The `modules` argument contains the Nix modules imported,
+i.e., included in the final configuration. This can be in the form of files
+which include nix code, or nix code embedded directly. `specialArgs` defines the
+arguments passed into the modules.
+
+`config.system.build.image` is the specific output of a built
+`micros.lib.microsSystem` which includes an ISO image of the distro.
+
+Alternatively, if building a container, this can be replaced with
+`config.system.build.ociImage`, which creates an OCI-compatible image, which can
 be imported into docker or any other LXC runtime. `nixpkgs.hostPlatform` defines
 the platform the image and its packages is intended to run on. This has a few
-available options, including "x86_64-linux", "x86_64-unknown-linux-musl",
-"aarch64-linux", and "armv7l-linux". Testing is primarily done on "x86_64-linux"
-for ISO images and "x86_64-unknown-linux-musl" for OCI images.
-`boot.isContainer = true` tells the micros builder to exclude kernel modules in
-the final image, and skip various kernel initialisation steps.
+available options, including `"x86_64-linux"`, `"x86_64-unknown-linux-musl"`,
+`"aarch64-linux"`, and `"armv7l-linux"`. Testing is primarily done on
+`"x86_64-linux"` for ISO images, and `"x86_64-unknown-linux-musl"` for OCI
+images. `boot.isContainer = true` tells the MicrOS builder to exclude kernel
+modules in the final image, and skip various kernel initialisation steps.
 
-## Configuration.nix file
+## `configuration.nix`
 
 The `configuration.nix` file defines the options set to generate the image. This
 includes:
 
-- Installed programs (both system-wide and user-wide)
 - Users
-- Services
+- Installed programs (both system-wide and user-wide via `user.packages` and
+  `programs.*` or such)
+- Services (`services.*`, `micros.services.*`, etc.)
+- Additionally imported files via `imports = []`
 
 The default content of the file is the following:
 
@@ -118,53 +160,73 @@ The default content of the file is the following:
     micros = {
       uid = 1000;
       gid = 1000;
-      password = ""; # Blank password denotes passwordless login is allowed, use "!" (default) to disable password login entirely. To set a password, set this string to a hashed password using the `mkpasswd` command.
+
+      # Blank password denotes passwordless login is allowed, use "!" (default)
+      # to disable password login entirely. To set a password, set this string
+      # to a hashed password using the `mkpasswd` command.
+      password = ""; 
+      
+      # User-wide packages
       packages = [
         pkgs.vim
         pkgs.ssh
-      ]; # User-wide packages
+      ];
     };
   };
 
-  # Add a custom service
+  # Add a custom MicrOS service
   micros.services = {
     custom-service = {
-      startOnBoot = true; # Start the service with the rest of a system
-      type = "oneshot"; # Do not restart the service after it stops
+      startOnBoot = true; # start the service with the rest of a system
+      type = "oneshot"; # do not restart the service after it stops
+
+      # Run a basic hello world program.
       startScript = ''
         #!${pkgs.busybox}/bin/ash
 
-        exec ${pkgs.hello}
-      ''; # Run a basic hello world program.
+        exec ${pkgs.hello}/bin/hello
+      ''; 
     };
   };
 
+  # System-wide packages. Those are installed for all users.
   environment.systemPackages = [
     pkgs.curl
-  ]; # System-wide packages
+  ]; 
 
   networking.firewall.enable = true;
   networking.nftables.enable = true;
 }
 ```
 
-This file has a few key sections.`{pkgs, lib, ...}` defines the external
-variables passed into the file. This includes `pkgs`, which includes the
-packages given by `micros` and `nixpkgs`, and `lib`, which includes the
-functions given by `nixpkgs` and `micros`. All of the following options can be
-found in more detail in the micros documentation. `services.getty.enable = true`
-enables a pre-defined micros service. The `users` set defines a new user, the
-`micros` user, gives it a UID and GID, sets the password as blank, and gives it
-the `ssh` and `vim` packages. The `micros.services` set defines a custom service
-which runs a hello world program on boot. `environment.systemPackages` defines a
-list of packages which are installed system-wide. Finally,
-`networking.firewall.enable` and `networking.nftables.enable` enable the network
-firewalling. This is only a subset of the available options, and more can be
-found in the micros options documentation.
+The `configuration.nix` file has a few key sections:
 
-## Hardware-configuration.nix file
+- `{pkgs, lib, ...}` is the "argument set", and has us pass the special
+  arguments (remember `specialArgs`) defined by `microsSystem` to be passed down
+  to files that are a part of the module system, i.e., the underlying
+  `evalModules` call. This includes `pkgs`, which includes the packages given by
+  `micros` and `nixpkgs`, and `lib`, which includes the functions given by
+  `nixpkgs` and `micros`.
+- An implicit `configuration` section, which is the main attribute set. Contains
+  options like:
+  - The `users` set, which defines a new user (the `micros` user), gives it a
+    UID and GID, sets the password as blank, and gives it the `ssh` and `vim`
+    packages.
+  - The `micros.services` set defines a custom service, which runs a hello world
+    program on boot.
+  - `environment.systemPackages` defines a list of packages which are installed
+    system-wide.
+  - `networking.firewall.enable` and `networking.nftables.enable` enable the
+    network firewalling.
 
-The `hardware-configuration.nix` file sets the options for:
+  > [!NOTE]
+  > This is only a subset of the available options, and more can be found in the
+  > MicrOS options documentation.
+
+## `hardware-configuration.nix`
+
+`hardware-configuration.nix` is a conventional, but by no means a _necessary_
+file that _typically_ sets the options for:
 
 - Kernel configuration
 - Filesystem mounting
@@ -195,28 +257,30 @@ The default configuration is:
     "sata_vsc"
     # omitted the rest of the list for conciseness
   ];
+  
   fileSystems."/" = {
     device = "tmpfs";
     fsType = "tmpfs";
     neededForBoot = true;
   };
+  
   fileSystems."/iso" = {
     device = "/dev/disk/by-label/micros";
     fsType = "iso9660";
     options = ["ro"];
     neededForBoot = true;
   };
+  
   fileSystems."/nix/store" = {
     device = "/mnt-root/iso/root.squashfs";
     fsType = "squashfs";
     options = ["ro"];
     neededForBoot = true;
   };
-  networking.interfaces = [
-    {
-      name = "eth0";
-    }
-  ];
+  
+  networking.interfaces = [{
+    name = "eth0";
+  }];
 }
 ```
 
@@ -224,3 +288,9 @@ This file defines the kernel modules loaded on boot, the root filesystem, ISO
 mounting, and nix store mounting. It also defines the network interfaces used by
 the image. This file should not be included in container images, as these
 options are handled by the container runtime.
+
+You may discard `hardware-configuration.nix` if you please, and simply insert
+such options in other files that you wish to import. The contents of
+`hardware-configuration.nix` could, for example, be moved to `configuration.nix`
+or split into their own files like `kernel.nix`, `fs.nix`, `networking.nix`,
+etc.


### PR DESCRIPTION
General cleanup. Fixes some wording errors that I've noticed. Tried to stay true to your language/tone but revised for clarity and accuracy where I felt is necessary.

Also uses GFM admonitions as NDG supports them :)

Change-Id: Ie557134d9ebbb5e5ae1de57c3734109c6a6a6964